### PR TITLE
Catches similar Fortran issue and improved error messaging.

### DIFF
--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -658,6 +658,12 @@ TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_b) {
  * Test of get response in example 3, which uses a deferred provider, checking the values for several iterations.
  */
     TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_c) {
+
+/* Note that a runtime check in SetUp() prevents this from executing when it can't, but
+   this needs to be here to prevent compile-time errors if either of these flags is not
+   enabled. */
+#if ACTIVATE_PYTHON && NGEN_BMI_FORTRAN_ACTIVE
+
         int ex_index = 3;
 
         Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
@@ -666,9 +672,8 @@ TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_b) {
         double response, mod_0_input_1, mod_1_output_2;
         for (int i = 0; i < 39; i++) {
             // Note that we need to get this before the "current" get_response ...
-#if ACTIVATE_PYTHON
             mod_1_output_2 = get_friend_nested_var_value<Bmi_Py_Formulation>(formulation, 1, "OUTPUT_VAR_2");
-#endif
+
             response = formulation.get_response(i, 3600);
             // But we need to get this after the "current" get_response ...
             mod_0_input_1 = get_friend_nested_var_value<Bmi_Fortran_Formulation>(formulation, 0, "INPUT_VAR_1");
@@ -677,6 +682,9 @@ TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_b) {
                 EXPECT_EQ(mod_0_input_1, mod_1_output_2);
             }
         }
+
+#endif // ACTIVATE_PYTHON && NGEN_BMI_FORTRAN_ACTIVE
+
     }
 
 /**

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -4,6 +4,7 @@
 // Don't bother with the rest if none of these are active (although what are we really doing here, then?)
 #if NGEN_BMI_C_LIB_ACTIVE || NGEN_BMI_FORTRAN_ACTIVE || ACTIVATE_PYTHON
 
+#include "all.h"
 #include "Bmi_Testing_Util.hpp"
 #include <exception>
 #include <map>
@@ -440,11 +441,11 @@ void Bmi_Multi_Formulation_Test::SetUp() {
 
     /* ********************************** First example scenario (Fortran / C) ********************************** */
     #ifndef NGEN_BMI_C_LIB_ACTIVE
-    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 0 without BMI C functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 0 without BMI C functionality active" SOURCE_LOC);
     #endif // NGEN_BMI_C_LIB_ACTIVE
 
     #ifndef NGEN_BMI_FORTRAN_ACTIVE
-    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 0 without BMI Fortran functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 0 without BMI Fortran functionality active" SOURCE_LOC);
     #endif // NGEN_BMI_FORTRAN_ACTIVE
 
 
@@ -453,11 +454,11 @@ void Bmi_Multi_Formulation_Test::SetUp() {
     /* ********************************** Second example scenario ********************************** */
 
     #ifndef NGEN_BMI_FORTRAN_ACTIVE
-    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 1 without BMI Fortran functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 1 without BMI Fortran functionality active" SOURCE_LOC);
     #endif // NGEN_BMI_FORTRAN_ACTIVE
 
     #ifndef ACTIVATE_PYTHON
-    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 1 without BMI C functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 1 without BMI Python functionality active" SOURCE_LOC);
     #endif // ACTIVATE_PYTHON
 
     initializeTestExample(1, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)});


### PR DESCRIPTION
Similar issue can arise if Fortran support is disabled instead of Python... these changes catch both scenarios. Also improves/corrects error messaging in the same scenario at runtime.